### PR TITLE
Metrics Exporter Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ REFS
 - [Packet mark in a Cloud Native world, LPC](https://lpc.events/event/7/contributions/683/attachments/554/979/lpc20-pkt-mark-slides.pdf)
 - [VMware NSX IPFIX for Distributed Firewall](https://docs.vmware.com/en/VMware-NSX-Data-Center-for-vSphere/6.4/com.vmware.nsx.admin.doc/GUID-2C625B52-17F0-4604-B5C9-6DF1FA9A70F8.html)
 - [VMware NSX IPFIX for Logical Switch](https://docs.vmware.com/en/VMware-NSX-Data-Center-for-vSphere/6.4/com.vmware.nsx.admin.doc/GUID-6054CF07-3019-4539-A6CC-1F613E275E27.html)
+- [Comparison and Practice of packet processing implementations and acceleration methods (ja), Ebiken-san, Higebu-san, JANOG45](https://www.janog.gr.jp/meeting/janog45/program/pktfwd/)
+- [IN-kernel metadata propagation technique from XDP buffer to SKB](https://github.com/torvalds/linux/blob/master/samples/bpf/xdp2skb_meta_kern.c)
+- [Private Discussion for metadata practice in eBPF](https://netmoles.slack.com/archives/C01DYBEETN0/p1667363998874089)
+- [One of the Reference design for traffic control mech using eBPF(both xdp and tc), ENOG63 by Higebu-san](https://www.docswell.com/s/higebu/ZQWRMZ-xdp-based-mobile-network-data-plane#p21)
 
 ## Specification
 

--- a/pkg/flowctl/app.go
+++ b/pkg/flowctl/app.go
@@ -163,13 +163,13 @@ func NewCommandEbpfCodeDump() *cobra.Command {
 	return cmd
 }
 
-func getTcEbpfByteCode(netns, dev string) (string, error) {
+func getTcEbpfByteCode(netns, dev, direction string) (string, error) {
 	clsActIsEnabled, err := goroute2.ClsActIsEnabled(netns, dev)
 	if err != nil {
 		return "", err
 	}
 	if clsActIsEnabled {
-		rules, err := goroute2.ListTcFilterRules(netns, dev)
+		rules, err := goroute2.ListTcFilterRules(netns, dev, direction)
 		if err != nil {
 			return "", err
 		}
@@ -182,8 +182,8 @@ func getTcEbpfByteCode(netns, dev string) (string, error) {
 	return "", nil
 }
 
-func getFlowMeterByteCode(netns, dev string) (*FlowMeterByteCode, error) {
-	bpfname, err := getTcEbpfByteCode(netns, dev)
+func getFlowMeterByteCode(netns, dev, dir string) (*FlowMeterByteCode, error) {
+	bpfname, err := getTcEbpfByteCode(netns, dev, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/goroute2/link.go
+++ b/pkg/goroute2/link.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 Hiroki Shirokura.
+Copyright 2022 Keio University.
+Copyright 2022 Wide Project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goroute2
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wide-vsix/linux-flow-exporter/pkg/util"
+)
+
+type LinkDetailXdpProg struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Tag         string `json:"tag"`
+	Jited       int    `json:"jited"`
+	LoadTime    uint64 `json:"load_time"`
+	CreateByUid int    `json:"created_by_uid"`
+	BtfID       int    `json:"btf_id"`
+}
+
+type XdpMode int
+
+func (xm XdpMode) String() string {
+	switch int(xm) {
+	case 2:
+		return "generic"
+	case 1:
+		return "native"
+	default:
+		return "unknown"
+	}
+}
+
+type LinkDetailXdp struct {
+	Mode XdpMode           `json:"mode"`
+	Prog LinkDetailXdpProg `json:"prog"`
+}
+
+type LinkDetail struct {
+	Ifindex  int            `json:"ifindex"`
+	Ifname   string         `json:"ifname"`
+	Flags    []string       `json:"flags"`
+	Mtu      int            `json:"mtu"`
+	Xdp      *LinkDetailXdp `json:"xdp"`
+	LinkInfo *struct {
+		InfoKind string `json:"info_kind"`
+	} `json:"linkinfo"`
+}
+
+func GetLinkDetail(netns, dev string) (*LinkDetail, error) {
+	n := ""
+	if netns != "" {
+		n = fmt.Sprintf("ip netns exec %s", netns)
+	}
+	o, err := util.LocalExecutef("%s ip -j -d link show dev %s", n, dev)
+	if err != nil {
+		return nil, err
+	}
+	ld := []LinkDetail{}
+	if err := json.Unmarshal([]byte(o), &ld); err != nil {
+		return nil, err
+	}
+	return &ld[0], nil
+}

--- a/pkg/goroute2/tc.go
+++ b/pkg/goroute2/tc.go
@@ -43,12 +43,12 @@ type TcFilterRule struct {
 	} `json:"options"`
 }
 
-func ListTcFilterRules(netns, dev string) ([]TcFilterRule, error) {
+func ListTcFilterRules(netns, dev, dir string) ([]TcFilterRule, error) {
 	n := ""
 	if netns != "" {
 		n = fmt.Sprintf("ip netns exec %s", netns)
 	}
-	o, err := util.LocalExecutef("%s tc -j filter list dev %s egress", n, dev)
+	o, err := util.LocalExecutef("%s tc -j filter list dev %s %s", n, dev, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/execute.go
+++ b/pkg/util/execute.go
@@ -19,6 +19,7 @@ limitations under the License.
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 
@@ -31,13 +32,20 @@ func SetLocalExecuteSilence(v bool) {
 	silence = v
 }
 
-func LocalExecute(cmd string) (string, error) {
-	out, err := exec.Command("sh", "-c", cmd).Output()
-	if err != nil {
+func LocalExecute(cmdstr string) (string, error) {
+	stdoutbuf := bytes.Buffer{}
+	stderrbuf := bytes.Buffer{}
+
+	cmd := exec.Command("sh", "-c", cmdstr)
+	cmd.Stdout = &stdoutbuf
+	cmd.Stderr = &stderrbuf
+
+	if err := cmd.Run(); err != nil {
 		str := fmt.Sprintf("CommandExecute [%s] ", cmd)
 		str += color.RedString("Failed")
 		str += color.RedString("%s", err.Error())
-		fmt.Printf("%s\n", str)
+		println(str)
+		println(stderrbuf.String())
 		return "", err
 	}
 
@@ -46,7 +54,7 @@ func LocalExecute(cmd string) (string, error) {
 		str += color.GreenString("Success")
 		fmt.Printf("%s\n", str)
 	}
-	return string(out), nil
+	return stdoutbuf.String(), nil
 }
 
 func LocalExecutef(fs string, a ...interface{}) (string, error) {


### PR DESCRIPTION
## Changes

- new support `flowctl meter attach -f` to force-replace bpf byte-code (good for dev and operation)
- bpf filter code refresh (many change, type, func, map, etc..)
- metrics change
  - linux_flow_exporter_.*_[pkts,bytes]
    - asis: key {ifindex}
    - tobe: key {ingressIfindex, egressIfindex}
- stop support `flowctl meter attach --section SECTION`
  - tc-egress, tc-ingress is stricted