### PR TITLE
Change timestamp format to UNIX milliseconds epoch time

### DIFF
--- a/pkg/flowctl/ipfix.go
+++ b/pkg/flowctl/ipfix.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/wide-vsix/linux-flow-exporter/pkg/ebpfmap"
 	"github.com/wide-vsix/linux-flow-exporter/pkg/ipfix"
@@ -431,11 +432,18 @@ func flushCaches(config ipfix.Config) (int, error) {
 	return nFlows, nil
 }
 
+func epochMillisTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	nanos := t.UnixNano()
+	millis := nanos / int64(time.Millisecond)
+	enc.AppendInt64(millis)
+}
+
 func getlogger(out string) logr.Logger {
 	cfg := zap.NewProductionConfig()
 	cfg.OutputPaths = []string{
 		out,
 	}
+	cfg.EncoderConfig.EncodeTime = epochMillisTimeEncoder
 	zapLog, err := cfg.Build()
 	if err != nil {
 		panic(fmt.Sprintf("who watches the watchmen (%v)?", err))


### PR DESCRIPTION
**Before applying this patch**

The format of "ts" field is UNIX microseconds epoch time and the type of field is double.

```
{"level":"info","ts":1684466121.845932,"caller":"flowctl/ipfix.go:490","msg":"flowlog","bytes":875,"action":0,"src":"***","proto":6,"dport":80,"ingressIfindex":0,"egressIfindex":2,"pkts":6,"end":61676578097851,"dst":"***","sport":46376,"start":61676566628864,"finished":1}
{"level":"info","ts":1684466133.7725713,"caller":"flowctl/ipfix.go:490","msg":"flowlog","action":0,"end":61690867167672,"finished":1,"dst":"***","proto":6,"sport":50060,"egressIfindex":2,"bytes":583,"start":61690860166118,"src":"***","dport":80,"ingressIfindex":0,"pkts":6}
{"level":"info","ts":1684466137.7735415,"caller":"flowctl/ipfix.go:490","msg":"flowlog","finished":1,"dst":"***","proto":6,"dport":80,"ingressIfindex":0,"pkts":5,"bytes":511,"end":61696832197743,"src":"***","sport":40328,"egressIfindex":2,"action":0,"start":61696831402533}
```

**After applying this patch**

The format of "ts" field is UNIX milliseconds epoch time and the type of field is int.

```
{"level":"info","ts":1684469994990,"caller":"flowctl/ipfix.go:498","msg":"flowlog","ingressIfindex":0,"pkts":5,"end":65553462082102,"finished":1,"src":"***","proto":6,"sport":45940,"dport":80,"start":65543455896143,"dst":"***","egressIfindex":2,"bytes":2099,"action":0}
{"level":"info","ts":1684470002989,"caller":"flowctl/ipfix.go:498","msg":"flowlog","proto":6,"pkts":14,"bytes":1063,"start":65560973726629,"end":65562002617918,"finished":1,"dst":"***","sport":35752,"dport":80,"ingressIfindex":0,"egressIfindex":2,"action":0,"src":"***"}
{"level":"info","ts":1684470006989,"caller":"flowctl/ipfix.go:498","msg":"flowlog","proto":6,"sport":51056,"pkts":6,"end":65565989587552,"src":"***","dst":"***","dport":80,"ingressIfindex":0,"egressIfindex":2,"bytes":875,"action":0,"start":65565978370815,"finished":1}
```